### PR TITLE
Layout fixes

### DIFF
--- a/TabbedSplitViewController/TabbedSplitViewController/TabBar.swift
+++ b/TabbedSplitViewController/TabbedSplitViewController/TabBar.swift
@@ -47,6 +47,7 @@ class PKTabBar: UIViewController {
         super.viewDidLoad()
 
         view.backgroundColor = backgroundColor
+        view.accessibilityIdentifier = "Tab Bar Container"
 
         actionsBar.isCompact = true
 
@@ -57,7 +58,6 @@ class PKTabBar: UIViewController {
 
         tabBar.view.bottomAnchor.constraint(equalTo: actionsBar.view.topAnchor, constant: -8).isActive = true
 
-        view.layoutIfNeeded()
         tabBar.didMove(toParent: self)
         actionsBar.didMove(toParent: self)
 

--- a/TabbedSplitViewController/TabbedSplitViewController/TabbedSplitMainView.swift
+++ b/TabbedSplitViewController/TabbedSplitViewController/TabbedSplitMainView.swift
@@ -30,11 +30,6 @@ private let sideBarAnimationDuration: TimeInterval = 0.35
 @IBDesignable
 class PKTabbedSplitView: UIView {
 
-    var tabBarWidth: CGFloat = 70 {
-        didSet {
-            tabBarWidthConstraint.constant = tabBarWidth
-        }
-    }
     var masterViewWidth: CGFloat = 320 {
         didSet {
             masterViewWidthConstraint.constant = masterViewWidth
@@ -45,7 +40,6 @@ class PKTabbedSplitView: UIView {
             navigationBarWidthConstraint?.constant = navigationBarWidth
         }
     }
-    let tabBarWidthConstraint: NSLayoutConstraint
     let masterViewWidthConstraint: NSLayoutConstraint
     private(set) var navigationBarWidthConstraint: NSLayoutConstraint?
 
@@ -81,11 +75,6 @@ class PKTabbedSplitView: UIView {
     init(tabBarView: UIView, masterView: UIView, detailView: UIView) {
         stackViewItems = [tabBarView, masterView, detailView]
         stackViewItems.forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
-
-        tabBarWidthConstraint = tabBarView.widthAnchor.constraint(equalToConstant: tabBarWidth)
-        // For transitions when we only have tab bar during the transition,
-        //   i.e. we don't yet have other views in the stack view by the moment transition starts
-        tabBarWidthConstraint.priority = UILayoutPriority(995)
         masterViewWidthConstraint = masterView.widthAnchor.constraint(equalToConstant: masterViewWidth)
         // For a case when we don't have detail view and we stretch master to all the parent width
         masterViewWidthConstraint.priority = UILayoutPriority(900)
@@ -102,7 +91,21 @@ class PKTabbedSplitView: UIView {
             stackView.addArrangedSubview(view)
         }
 
-        addChildView(stackView)
+        if #available(iOS 11.0, *) {
+            addSubview(stackView)
+            stackView.translatesAutoresizingMaskIntoConstraints = false
+
+            let constraints = [
+                stackView.leftAnchor.constraint(equalTo: leftAnchor),
+                stackView.topAnchor.constraint(equalTo: topAnchor),
+                stackView.rightAnchor.constraint(equalTo: safeAreaLayoutGuide.rightAnchor),
+                stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            ]
+            NSLayoutConstraint.activate(constraints)
+        }
+        else {
+            addChildView(stackView)
+        }
     }
 
     public required init?(coder aDecoder: NSCoder) {
@@ -254,7 +257,7 @@ class PKTabbedSplitView: UIView {
 
     /// Creates a side bar then adds a master view there.
     /// Should be called after removing the view from the stack view!
-    func addMasterSideBar() {
+    func addMasterSideBar(tabBarWidth: CGFloat) {
         logger?.log("Entered")
         sideBarIsHidden = true
         let sideBarView = self.view(for: .master)

--- a/TabbedSplitViewControllerDemo/TabbedSplitViewControllerDemo/AppDelegate.swift
+++ b/TabbedSplitViewControllerDemo/TabbedSplitViewControllerDemo/AppDelegate.swift
@@ -154,3 +154,27 @@ extension UIViewController {
     
 }
 
+extension UIUserInterfaceIdiom: CustomStringConvertible {
+
+    public var description: String {
+        switch self {
+        case .unspecified: return ".unspecified"
+        case .phone: return ".phone"
+        case .pad: return ".pad"
+        case .tv: return ".tv"
+        case .carPlay: return ".carPlay"
+        }
+    }
+}
+
+extension UIUserInterfaceSizeClass: CustomStringConvertible {
+
+    public var description: String {
+        switch self {
+        case .unspecified: return ".unspecified"
+        case .compact: return ".compact"
+        case .regular: return ".regular"
+        }
+    }
+}
+

--- a/TabbedSplitViewControllerDemo/TabbedSplitViewControllerDemo/DetailController.swift
+++ b/TabbedSplitViewControllerDemo/TabbedSplitViewControllerDemo/DetailController.swift
@@ -53,6 +53,12 @@ class DetailController: UIViewController {
         button.addTarget(self, action: #selector(openModalScreen), for: .touchUpInside)
     }
 
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        print("viewDidLayoutSubviews(): Detail view width: \(view.frame.width)")
+    }
+
     @objc private func closeDetail(_ sender: UIBarButtonItem) {
         onCloseButtonPressed?(true)
     }


### PR DESCRIPTION
• Multiple fixes for broken constraints
• A fix for smashed tab bar on iPhone in landscape
• Support for the safe area for all sides

Tab bar container now does not have fixed, but the tab bar and the action bar have; they are aligned with the safe area on the left the way that background color you assigned to the tab bar goes all the way to the left.

Had to come up with the estimated safe area insets in the `viewWillAppear` as at that time the real insets aren't available yet.